### PR TITLE
Fix endianness for NFLOG config attributes

### DIFF
--- a/nflog.go
+++ b/nflog.go
@@ -83,13 +83,13 @@ func Open(config *Config) (*Nflog, error) {
 	}
 
 	nflog.flags = []byte{0x00, 0x00}
-	nativeEndian.PutUint16(nflog.flags, config.Flags)
+	binary.BigEndian.PutUint16(nflog.flags, config.Flags)
 	nflog.timeout = []byte{0x00, 0x00, 0x00, 0x00}
-	nativeEndian.PutUint32(nflog.timeout, config.Timeout)
+	binary.BigEndian.PutUint32(nflog.timeout, config.Timeout)
 	nflog.bufsize = []byte{0x00, 0x00, 0x00, 0x00}
-	nativeEndian.PutUint32(nflog.bufsize, config.Bufsize)
+	binary.BigEndian.PutUint32(nflog.bufsize, config.Bufsize)
 	nflog.qthresh = []byte{0x00, 0x00, 0x00, 0x00}
-	nativeEndian.PutUint32(nflog.qthresh, config.QThresh)
+	binary.BigEndian.PutUint32(nflog.qthresh, config.QThresh)
 	nflog.group = config.Group
 	nflog.copyMode = config.Copymode
 	nflog.settings = config.Settings


### PR DESCRIPTION
The kernel expects the NFULA_CFG_QTHRESH, NFULA_CFG_NLBUFSIZ, NFULA_CFG_TIMEOUT
and NFULA_CFG_FLAGS attributes to be in network byteorder (big-endian).

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/netfilter/nfnetlink_log.c?h=v5.9#n871

The impact of the endianness bug is, that for example setting nflog.FlagConntrack has no effect on the kernel (eg. it always returns the NFLOG messages w/o any conntrack information).