### PR TITLE
Fix endianness of conntrack attributes

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -105,11 +105,15 @@ func extractAttribute(a *Attribute, logger *log.Logger, data []byte) error {
 			a.HwLen = &hwLen
 			ad.ByteOrder = nativeEndian
 		case nfUlaAttrCt + netlink.Nested:
+			ad.ByteOrder = binary.BigEndian
 			ct := ad.Bytes()
 			a.Ct = &ct
+			ad.ByteOrder = nativeEndian
 		case nfUlaAttrCtInfo:
+			ad.ByteOrder = binary.BigEndian
 			ctInfo := ad.Uint32()
 			a.CtInfo = &ctInfo
+			ad.ByteOrder = nativeEndian
 		default:
 			logger.Printf("Unknown attribute: %d %v\n", ad.Type(), ad.Bytes())
 		}


### PR DESCRIPTION
The kernel puts the values of NFULA_CT_INFO and NFULA_CT in network byteorder (big-endian).

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/netfilter/nf_conntrack_netlink.c?h=v5.9#n2773