### PR TITLE
Support AF_BRIDGE familiy frames from ebtables

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -137,7 +137,7 @@ func extractAttribute(a *Attribute, logger *log.Logger, data []byte) error {
 }
 
 func checkHeader(data []byte) int {
-	if (data[0] == unix.AF_INET || data[0] == unix.AF_INET6) && data[1] == unix.NFNETLINK_V0 {
+	if (data[0] == unix.AF_INET || data[0] == unix.AF_INET6 || data[0] == unix.AF_BRIDGE) && data[1] == unix.NFNETLINK_V0 {
 		return 4
 	}
 	return 0

--- a/internal/unix/types_linux.go
+++ b/internal/unix/types_linux.go
@@ -12,4 +12,5 @@ const (
 	AF_UNSPEC         = linux.AF_UNSPEC
 	AF_INET           = linux.AF_INET
 	AF_INET6          = linux.AF_INET6
+	AF_BRIDGE         = linux.AF_BRIDGE
 )

--- a/internal/unix/types_other.go
+++ b/internal/unix/types_other.go
@@ -10,4 +10,5 @@ const (
 	AF_UNSPEC         = 0x0
 	AF_INET           = 0x2
 	AF_INET6          = 0xa
+	AF_BRIDGE         = 0x7
 )


### PR DESCRIPTION
checkHeader() should return 4 for AF_BRIDGE familiy frames as well.

Tested by capturing STP and DHCP frames from ebtables nflog.