### PR TITLE
add `config.SkipErrorENOBUFS` option

### DIFF
--- a/nflog.go
+++ b/nflog.go
@@ -76,6 +76,12 @@ func Open(config *Config) (*Nflog, error) {
 	if err != nil {
 		return nil, err
 	}
+	if config.SkipErrorENOBUFS {
+		if err := con.SetOption(netlink.NoENOBUFS, true); err != nil {
+			con.Close()
+			return nil, err
+		}
+	}
 	nflog.Con = con
 
 	if config.Logger == nil {

--- a/types.go
+++ b/types.go
@@ -151,6 +151,12 @@ type Config struct {
 	// Optional settings to enable/disable features
 	Settings uint16
 
+	// If SkipErrorENOBUFS is set to "true", it will skip the "ENOBUFS" error,
+	// normally, the "ENOBUFS" error would close the netlink socket if there are a lot of messages,
+	// however, enabling this option allows the socket to continue working
+	// (at the cost of potentially losing some messages)
+	SkipErrorENOBUFS bool
+
 	// Time till a read action times out - only available for Go >= 1.12
 	//
 	// Deprecated: Cancel the context passed to RegisterWithErrorFunc() or Register()


### PR DESCRIPTION
Im just upstreaming patches that I had on my company hardfork since 5years.
When I have a lot of messages on netlink, I may get an ENOBUFS error, which causes netlink to close its socket.
This NoENOBUFS option causes the socket to continue working, but will lose some of the messages.

Some more info about ENOBUFS: https://github.com/google/nftables/issues/103